### PR TITLE
Initial fix for issue #21

### DIFF
--- a/OpenScadJob.py
+++ b/OpenScadJob.py
@@ -1,3 +1,7 @@
+import os
+import shutil
+import tempfile
+
 from UM.Job import Job
 
 from . import OpenScadInterface
@@ -21,4 +25,24 @@ class OpenScadJob(Job):
 
     def run(self) -> None:
         '''Generate an STL from an OpenSCAD file'''
-        self._openScadInterface.GenerateStl(self._openScadFilePath, self._openScadParameters, self._stlFilePath)
+
+        # Check if the openscad file is in a symbolically-linked directory
+        # OpenScad apparently can't handle source files in symbolically-linked directories (at least on Windows)
+        openScadFileDir = os.path.dirname(self._openScadFilePath)
+        if os.path.islink(openScadFileDir):
+
+            # Copy the file to the system's temporary directory
+            openScadFileName = os.path.basename(self._openScadFilePath)
+            tempDir = tempfile.gettempdir()
+            tempOpenScadFilePath = os.path.join(tempDir, openScadFileName)
+            shutil.copy2(self._openScadFilePath, tempOpenScadFilePath)
+
+            # Run openscad with the temporary file
+            self._openScadInterface.GenerateStl(tempOpenScadFilePath, self._openScadParameters, self._stlFilePath)
+
+            # Delete the temporary file
+            os.remove(tempOpenScadFilePath)
+
+        # If this is just a normal, everyday file, run openscad normally
+        else:
+            self._openScadInterface.GenerateStl(self._openScadFilePath, self._openScadParameters, self._stlFilePath)

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "Auto Towers Generator",
     "author": "Brad Kartchner",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "api": 7,
     "supported_sdk_versions": ["7.9.0", "8.0.0", "8.1.0", "8.2.0"],
     "description": "Automates the generation of several parameterized calibration models.",


### PR DESCRIPTION
If OpenScad source files are in symlinked dirs, they are copied to a temporary directory before being passed to OpenScad