### PR TITLE
use the user supplied section size to calculate the section layers

### DIFF
--- a/Controllers/FlowTowerController.py
+++ b/Controllers/FlowTowerController.py
@@ -222,7 +222,7 @@ class FlowTowerController(ControllerBase):
         baseHeight = self._baseLayers * layerHeight
 
         # Correct the section height to ensure an integer number of layers per section
-        self._sectionLayers = math.ceil(self._nominalSectionHeight / layerHeight) # Round up
+        self._sectionLayers = math.ceil(self.sectionSize / layerHeight) # Round up
         sectionHeight = self._sectionLayers * layerHeight
 
         # Ensure the change amount has the correct sign

--- a/Controllers/FlowTowerController.py
+++ b/Controllers/FlowTowerController.py
@@ -222,7 +222,7 @@ class FlowTowerController(ControllerBase):
         baseHeight = self._baseLayers * layerHeight
 
         # Correct the section height to ensure an integer number of layers per section
-        self._sectionLayers = math.ceil(self.sectionSize / layerHeight) # Round up
+        self._sectionLayers = math.ceil(sectionSize / layerHeight) # Round up
         sectionHeight = self._sectionLayers * layerHeight
 
         # Ensure the change amount has the correct sign


### PR DESCRIPTION
I noticed the custom flow tower was changing the flow mid sections when I supplied it with a section size of 10. I think I found the culprit, it seems the calculations weren't using the user supplied section size.