### PR TITLE
Don't quote a quoted path

### DIFF
--- a/OpenScadInterface.py
+++ b/OpenScadInterface.py
@@ -86,9 +86,11 @@ class OpenScadInterface:
                 # Prefix the OpenScad call with a command to unset LD_LIBRARY_PATH
                 command += 'unset LD_LIBRARY_PATH; '
 
+            path = self.OpenScadPath
+
             # Add the executable to the command
-            # Quotes are added in case there are embedded spaces in the path
-            command += f'"{self.OpenScadPath}"'
+            # Quotes are added in case there are embedded spaces in the path, but we shouldn't double up if already quoted
+            command += f'"{path}"' if not path.startswith('\"') else path
 
         return command
 


### PR DESCRIPTION
When a quoted path is entered in through settings, the path is considered correct - the version is correctly captured.

At the same time, the plugin will fail generating the tower with openSCAD because it'll try to invoke a quoted-quoted command.

It's important to note that quoting is default if one obtains the path by going to executable and clicking "copy as path" in Windows.