### PR TITLE
Corrected ToolTip for Ending Temperature

### DIFF
--- a/Resources/QML/QT6/TempTowerDialog.qml
+++ b/Resources/QML/QT6/TempTowerDialog.qml
@@ -93,7 +93,7 @@ UM.Dialog
             }
             UM.ToolTip
             {
-                text: "The nozzle temperature for the last section of the tower.<p>It is good practice to make this temperature lower than the ending temperature."
+                text: "The nozzle temperature for the last section of the tower.<p>It is good practice to make this temperature lower than the starting temperature."
                 visible: ending_temperature_mouse_area.containsMouse
             }
 


### PR DESCRIPTION
The ToolTip for the ending temperature says "It is good practice to make this temperature lower than the **ending** temperature." - This should be "lower than the **starting** temperature".